### PR TITLE
Fix relative path to ciDict.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-##[6.0.4]
+## [6.0.4]
 - [Ruby] Fix relative path to ciDict.json ([PR#13](https://github.com/cucumber/create-meta/pull/13))
 
 ## [6.0.3] - 2021-11-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+##[6.0.4]
+- [Ruby] Fix relative path to ciDict.json ([PR#13](https://github.com/cucumber/create-meta/pull/13))
+
 ## [6.0.3] - 2021-11-15
 ### Fixed
 - [JavaScript] Removed tag property from git object if it is undefined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [6.0.4]
-- [Ruby] Fix relative path to ciDict.json ([PR#13](https://github.com/cucumber/create-meta/pull/13))
+- [Ruby][Java] Fix ciDict.json was missing from the Ruby Gem and the Java Artifact
+  ([PR#13](https://github.com/cucumber/create-meta/pull/13))
 
 ## [6.0.3] - 2021-11-15
 ### Fixed

--- a/java/src/main/java/io/cucumber/createmeta/CreateMeta.java
+++ b/java/src/main/java/io/cucumber/createmeta/CreateMeta.java
@@ -12,7 +12,6 @@ import io.cucumber.messages.types.Product;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.FileInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -24,10 +23,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class CreateMeta {
     private static final JsonObject CI_DICT;
-    private static final String JSON_PATH = "../ciDict.json";
+    private static final String JSON_PATH = "/io/cucumber/createmeta/ciDict.json";
 
     static {
-        try (Reader reader = new InputStreamReader(new FileInputStream(JSON_PATH), UTF_8)) {
+        try (Reader reader = new InputStreamReader(CreateMeta.class.getResourceAsStream(JSON_PATH), UTF_8)) {
             CI_DICT = Json.parse(reader).asObject();
         } catch (IOException e) {
             throw new RuntimeException("Unable to parse " + JSON_PATH, e);

--- a/java/src/main/resources/io/cucumber/createmeta/ciDict.json
+++ b/java/src/main/resources/io/cucumber/createmeta/ciDict.json
@@ -1,0 +1,142 @@
+{
+  "Azure Pipelines": {
+    "url": "${BUILD_BUILDURI}",
+    "buildNumber": "${BUILD_BUILDNUMBER}",
+    "git": {
+      "remote": "${BUILD_REPOSITORY_URI}",
+      "revision": "${BUILD_SOURCEVERSION}",
+      "branch": "${BUILD_SOURCEBRANCH/refs\/heads\/(.*)/\\1}",
+      "tag": "${BUILD_SOURCEBRANCH/refs\/tags\/(.*)/\\1}"
+    }
+  },
+  "Bamboo": {
+    "url": "${bamboo_buildResultsUrl}",
+    "buildNumber": "${bamboo_buildNumber}",
+    "git": {
+      "remote": "${bamboo_planRepository_repositoryUrl}",
+      "revision": "${bamboo_planRepository_revision}",
+      "branch": "${bamboo_planRepository_branch}",
+      "tag": null
+    }
+  },
+  "Buddy": {
+    "url": "${BUDDY_EXECUTION_URL}",
+    "buildNumber": "${BUDDY_EXECUTION_ID}",
+    "git": {
+      "remote": "${BUDDY_SCM_URL}",
+      "revision": "${BUDDY_EXECUTION_REVISION}",
+      "branch": "${BUDDY_EXECUTION_BRANCH}",
+      "tag": "${BUDDY_EXECUTION_TAG}"
+    }
+  },
+  "Bitrise": {
+    "url": "${BITRISE_BUILD_URL}",
+    "buildNumber": "${BITRISE_BUILD_NUMBER}",
+    "git": {
+      "remote": "${GIT_REPOSITORY_URL}",
+      "revision": "${BITRISE_GIT_COMMIT}",
+      "branch": "${BITRISE_GIT_BRANCH}",
+      "tag": "${BITRISE_GIT_TAG}"
+    }
+  },
+  "CircleCI": {
+    "url": "${CIRCLE_BUILD_URL}",
+    "buildNumber": "${CIRCLE_BUILD_NUM}",
+    "git": {
+      "remote": "${CIRCLE_REPOSITORY_URL}",
+      "revision": "${CIRCLE_SHA1}",
+      "branch": "${CIRCLE_BRANCH}",
+      "tag": "${CIRCLE_TAG}"
+    }
+  },
+  "CodeFresh": {
+    "url": "${CF_BUILD_URL}",
+    "buildNumber": "${CF_BUILD_ID}",
+    "git": {
+      "remote": "${CF_COMMIT_URL/(.*)\\/commit.+$/\\1}.git",
+      "revision": "${CF_REVISION}",
+      "branch": "${CF_BRANCH}",
+      "tag": null
+    }
+  },
+  "CodeShip": {
+    "url": "${CI_BUILD_URL}",
+    "buildNumber": "${CI_BUILD_NUMBER}",
+    "git": {
+      "remote": "${CI_PULL_REQUEST/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${CI_COMMIT_ID}",
+      "branch": "${CI_BRANCH}",
+      "tag": null
+    }
+  },
+  "GitHub Actions": {
+    "url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
+    "buildNumber": "${GITHUB_RUN_ID}",
+    "git": {
+      "remote": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git",
+      "revision": "${GITHUB_SHA}",
+      "branch": "${GITHUB_REF/refs\/heads\/(.*)/\\1}",
+      "tag": "${GITHUB_REF/refs\/tags\/(.*)/\\1}"
+    }
+  },
+  "GitLab": {
+    "url": "${CI_JOB_URL}",
+    "buildNumber": "${CI_JOB_ID}",
+    "git": {
+      "remote": "${CI_REPOSITORY_URL}",
+      "revision": "${CI_COMMIT_SHA}",
+      "branch": "${CI_COMMIT_BRANCH}",
+      "tag": "${CI_COMMIT_TAG}"
+    }
+  },
+  "GoCD": {
+    "url": "${GO_SERVER_URL}/pipelines/${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
+    "buildNumber": "${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
+    "git": {
+      "remote": "${GO_SCM_*_PR_URL/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${GO_REVISION}",
+      "branch": "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}",
+      "tag": null
+    }
+  },
+  "Jenkins": {
+    "url": "${BUILD_URL}",
+    "buildNumber": "${BUILD_NUMBER}",
+    "git": {
+      "remote": "${GIT_URL}",
+      "revision": "${GIT_COMMIT}",
+      "branch": "${GIT_LOCAL_BRANCH}",
+      "tag": null
+    }
+  },
+  "Semaphore": {
+    "url": "${SEMAPHORE_ORGANIZATION_URL}/jobs/${SEMAPHORE_JOB_ID}",
+    "buildNumber": "${SEMAPHORE_JOB_ID}",
+    "git": {
+      "remote": "${SEMAPHORE_GIT_URL}",
+      "revision": "${SEMAPHORE_GIT_SHA}",
+      "branch": "${SEMAPHORE_GIT_BRANCH}",
+      "tag": "${SEMAPHORE_GIT_TAG_NAME}"
+    }
+  },
+  "Travis CI": {
+    "url": "${TRAVIS_BUILD_WEB_URL}",
+    "buildNumber": "${TRAVIS_JOB_NUMBER}",
+    "git": {
+      "remote": "https://github.com/${TRAVIS_REPO_SLUG}.git",
+      "revision": "${TRAVIS_COMMIT}",
+      "branch": "${TRAVIS_BRANCH}",
+      "tag": "${TRAVIS_TAG}"
+    }
+  },
+  "Wercker": {
+    "url": "${WERCKER_RUN_URL}",
+    "buildNumber": "${WERCKER_RUN_URL/.*\\/([^\\/]+)$/\\1}",
+    "git": {
+      "remote": "https://${WERCKER_GIT_DOMAIN}/${WERCKER_GIT_OWNER}/${WERCKER_GIT_REPOSITORY}.git",
+      "revision": "${WERCKER_GIT_COMMIT}",
+      "branch": "${WERCKER_GIT_BRANCH}",
+      "tag": null
+    }
+  }
+}

--- a/ruby/lib/cucumber/ciDict.json
+++ b/ruby/lib/cucumber/ciDict.json
@@ -1,0 +1,142 @@
+{
+  "Azure Pipelines": {
+    "url": "${BUILD_BUILDURI}",
+    "buildNumber": "${BUILD_BUILDNUMBER}",
+    "git": {
+      "remote": "${BUILD_REPOSITORY_URI}",
+      "revision": "${BUILD_SOURCEVERSION}",
+      "branch": "${BUILD_SOURCEBRANCH/refs\/heads\/(.*)/\\1}",
+      "tag": "${BUILD_SOURCEBRANCH/refs\/tags\/(.*)/\\1}"
+    }
+  },
+  "Bamboo": {
+    "url": "${bamboo_buildResultsUrl}",
+    "buildNumber": "${bamboo_buildNumber}",
+    "git": {
+      "remote": "${bamboo_planRepository_repositoryUrl}",
+      "revision": "${bamboo_planRepository_revision}",
+      "branch": "${bamboo_planRepository_branch}",
+      "tag": null
+    }
+  },
+  "Buddy": {
+    "url": "${BUDDY_EXECUTION_URL}",
+    "buildNumber": "${BUDDY_EXECUTION_ID}",
+    "git": {
+      "remote": "${BUDDY_SCM_URL}",
+      "revision": "${BUDDY_EXECUTION_REVISION}",
+      "branch": "${BUDDY_EXECUTION_BRANCH}",
+      "tag": "${BUDDY_EXECUTION_TAG}"
+    }
+  },
+  "Bitrise": {
+    "url": "${BITRISE_BUILD_URL}",
+    "buildNumber": "${BITRISE_BUILD_NUMBER}",
+    "git": {
+      "remote": "${GIT_REPOSITORY_URL}",
+      "revision": "${BITRISE_GIT_COMMIT}",
+      "branch": "${BITRISE_GIT_BRANCH}",
+      "tag": "${BITRISE_GIT_TAG}"
+    }
+  },
+  "CircleCI": {
+    "url": "${CIRCLE_BUILD_URL}",
+    "buildNumber": "${CIRCLE_BUILD_NUM}",
+    "git": {
+      "remote": "${CIRCLE_REPOSITORY_URL}",
+      "revision": "${CIRCLE_SHA1}",
+      "branch": "${CIRCLE_BRANCH}",
+      "tag": "${CIRCLE_TAG}"
+    }
+  },
+  "CodeFresh": {
+    "url": "${CF_BUILD_URL}",
+    "buildNumber": "${CF_BUILD_ID}",
+    "git": {
+      "remote": "${CF_COMMIT_URL/(.*)\\/commit.+$/\\1}.git",
+      "revision": "${CF_REVISION}",
+      "branch": "${CF_BRANCH}",
+      "tag": null
+    }
+  },
+  "CodeShip": {
+    "url": "${CI_BUILD_URL}",
+    "buildNumber": "${CI_BUILD_NUMBER}",
+    "git": {
+      "remote": "${CI_PULL_REQUEST/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${CI_COMMIT_ID}",
+      "branch": "${CI_BRANCH}",
+      "tag": null
+    }
+  },
+  "GitHub Actions": {
+    "url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
+    "buildNumber": "${GITHUB_RUN_ID}",
+    "git": {
+      "remote": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git",
+      "revision": "${GITHUB_SHA}",
+      "branch": "${GITHUB_REF/refs\/heads\/(.*)/\\1}",
+      "tag": "${GITHUB_REF/refs\/tags\/(.*)/\\1}"
+    }
+  },
+  "GitLab": {
+    "url": "${CI_JOB_URL}",
+    "buildNumber": "${CI_JOB_ID}",
+    "git": {
+      "remote": "${CI_REPOSITORY_URL}",
+      "revision": "${CI_COMMIT_SHA}",
+      "branch": "${CI_COMMIT_BRANCH}",
+      "tag": "${CI_COMMIT_TAG}"
+    }
+  },
+  "GoCD": {
+    "url": "${GO_SERVER_URL}/pipelines/${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
+    "buildNumber": "${GO_PIPELINE_NAME}/${GO_PIPELINE_COUNTER}/${GO_STAGE_NAME}/${GO_STAGE_COUNTER}",
+    "git": {
+      "remote": "${GO_SCM_*_PR_URL/(.*)\\/pull\\/\\d+/\\1.git}",
+      "revision": "${GO_REVISION}",
+      "branch": "${GO_SCM_*_PR_BRANCH/.*:(.*)/\\1}",
+      "tag": null
+    }
+  },
+  "Jenkins": {
+    "url": "${BUILD_URL}",
+    "buildNumber": "${BUILD_NUMBER}",
+    "git": {
+      "remote": "${GIT_URL}",
+      "revision": "${GIT_COMMIT}",
+      "branch": "${GIT_LOCAL_BRANCH}",
+      "tag": null
+    }
+  },
+  "Semaphore": {
+    "url": "${SEMAPHORE_ORGANIZATION_URL}/jobs/${SEMAPHORE_JOB_ID}",
+    "buildNumber": "${SEMAPHORE_JOB_ID}",
+    "git": {
+      "remote": "${SEMAPHORE_GIT_URL}",
+      "revision": "${SEMAPHORE_GIT_SHA}",
+      "branch": "${SEMAPHORE_GIT_BRANCH}",
+      "tag": "${SEMAPHORE_GIT_TAG_NAME}"
+    }
+  },
+  "Travis CI": {
+    "url": "${TRAVIS_BUILD_WEB_URL}",
+    "buildNumber": "${TRAVIS_JOB_NUMBER}",
+    "git": {
+      "remote": "https://github.com/${TRAVIS_REPO_SLUG}.git",
+      "revision": "${TRAVIS_COMMIT}",
+      "branch": "${TRAVIS_BRANCH}",
+      "tag": "${TRAVIS_TAG}"
+    }
+  },
+  "Wercker": {
+    "url": "${WERCKER_RUN_URL}",
+    "buildNumber": "${WERCKER_RUN_URL/.*\\/([^\\/]+)$/\\1}",
+    "git": {
+      "remote": "https://${WERCKER_GIT_DOMAIN}/${WERCKER_GIT_OWNER}/${WERCKER_GIT_REPOSITORY}.git",
+      "revision": "${WERCKER_GIT_COMMIT}",
+      "branch": "${WERCKER_GIT_BRANCH}",
+      "tag": null
+    }
+  }
+}

--- a/ruby/lib/cucumber/create_meta.rb
+++ b/ruby/lib/cucumber/create_meta.rb
@@ -7,25 +7,25 @@ require 'cucumber/create_meta/variable_expression'
 module Cucumber
   module CreateMeta
     extend Cucumber::CreateMeta::VariableExpression
-    CI_DICT = JSON.parse(IO.read(File.join(File.dirname(__FILE__), '..', '..', 'ciDict.json')))
+    CI_DICT = JSON.parse(IO.read(File.join(File.dirname(__FILE__), 'ciDict.json')))
 
     def create_meta(tool_name, tool_version, env = ENV)
       Cucumber::Messages::Meta.new(
         protocol_version: Cucumber::Messages::VERSION,
         implementation: Cucumber::Messages::Product.new(
-            name: tool_name,
-            version: tool_version
+          name: tool_name,
+          version: tool_version
         ),
         runtime: Cucumber::Messages::Product.new(
-            name: RUBY_ENGINE,
-            version: RUBY_VERSION
+          name: RUBY_ENGINE,
+          version: RUBY_VERSION
         ),
         os: Cucumber::Messages::Product.new(
-            name: RbConfig::CONFIG['target_os'],
-            version: Sys::Uname.uname.version
+          name: RbConfig::CONFIG['target_os'],
+          version: Sys::Uname.uname.version
         ),
         cpu: Cucumber::Messages::Product.new(
-            name: RbConfig::CONFIG['target_cpu']
+          name: RbConfig::CONFIG['target_cpu']
         ),
         ci: detect_ci(env)
       )
@@ -51,18 +51,19 @@ module Cucumber
           remote: remove_userinfo_from_url(evaluate(ci_system['git']['remote'], env)),
           revision: evaluate(ci_system['git']['revision'], env),
           branch: evaluate(ci_system['git']['branch'], env),
-          tag: evaluate(ci_system['git']['tag'], env),
+          tag: evaluate(ci_system['git']['tag'], env)
         )
       )
     end
 
     def remove_userinfo_from_url(value)
       return nil if value.nil?
+
       begin
         uri = URI(value)
         uri.userinfo = ''
         uri.to_s
-      rescue
+      rescue StandardError
         value
       end
     end

--- a/ruby/lib/cucumber/create_meta.rb
+++ b/ruby/lib/cucumber/create_meta.rb
@@ -7,7 +7,7 @@ require 'cucumber/create_meta/variable_expression'
 module Cucumber
   module CreateMeta
     extend Cucumber::CreateMeta::VariableExpression
-    CI_DICT = JSON.parse(IO.read(File.join(File.dirname(__FILE__), '..', '..', '..', 'ciDict.json')))
+    CI_DICT = JSON.parse(IO.read(File.join(File.dirname(__FILE__), '..', '..', 'ciDict.json')))
 
     def create_meta(tool_name, tool_version, env = ENV)
       Cucumber::Messages::Meta.new(


### PR DESCRIPTION
# Description

Pulling the latest release and running my local Rake task fails with

```
/Users/me/.rvm/gems/ruby-2.5.7/gems/cucumber-create-meta-6.0.3/lib/cucumber/create_meta.rb:10:in `read': No such file or directory @ rb_sysopen - /Users/me/.rvm/gems/ruby-2.5.7/gems/cucumber-create-meta-6.0.3/lib/cucumber/../../../ciDict.json (Errno::ENOENT)
```

Running

```
wget https://raw.githubusercontent.com/cucumber/create-meta/main/ciDict.json
```

in `/Users/me/.rvm/gems/ruby-2.5.7/gems/` fixes the issue. I believe I found where a relative path is being constructed incorrectly.

# Motivation & context

Fix the gem.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Note to other contributors

None

## Update required of cucumber.io/docs

Not required

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
